### PR TITLE
Define getopt externals as "C"

### DIFF
--- a/src/Foundational/cmdline/cmdline.cc
+++ b/src/Foundational/cmdline/cmdline.cc
@@ -9,9 +9,9 @@
 // Unclear when we need to switch between C and C++ bindings for optxxx
 #if defined(_WIN32) || defined(NEED_EXTERN_OPT)
 /* Global Exportable */
- extern int optind;
- extern char *optarg;
- extern int opterr;
+ extern "C" int optind;
+ extern "C" char *optarg;
+ extern "C" int opterr;
 
 #else
 #include <unistd.h>


### PR DESCRIPTION
Newer versions of GCC (I think 8 onwards, I am using 9.2.1) enforce declaring the language type of non C++ externs, while older ones incorrectly (I believe) do not. This fixes compilation on gcc 9.2.1 (using the rhel7 makefile)